### PR TITLE
Fix typo in README.md command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you aren't using conda
 git clone https://github.com/TomAugspurger/dask-tutorial-pycon-2018
 
 # Enter the repository
-cd dsak-tutorial-pycon-2018
+cd dask-tutorial-pycon-2018
 
 # Create a virtualenv
 python3 -m venv .env


### PR DESCRIPTION
Fix path for the sake of others who might extract this part of the README into a script.